### PR TITLE
Switch to lodash.mergewith

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lodash.foreach": "^3.0.3",
     "lodash.isequal": "^3.0.4",
     "lodash.isundefined": "^3.0.1",
-    "lodash.merge": "^3.3.2",
+    "lodash.mergewith": "^4.6.2",
     "lodash.sortby": "^3.1.5"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var _ = {
-    merge: require('lodash.merge'),
+    merge: require('lodash.mergewith'),
     each: require('lodash.foreach'),
     findIndex: require('lodash.findindex'),
     isEqual: require('lodash.isequal'),


### PR DESCRIPTION
The old `lodash.merge`, which this project uses, has been renamed to `mergewith`. Our project depends on this package, and the older version of Lodash has a high-level vulnerability. Hence, this PR to update it and clear our security alerts.